### PR TITLE
Tests: Use PHPStan 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
         "codeception/util-universalframework": "^1.0",
         "php-webdriver/webdriver": "<=1.14.0",
         "wp-coding-standards/wpcs": "^3.0.0",
-        "phpstan/phpstan": "^1.7",
-        "szepeviktor/phpstan-wordpress": "^1.0",
-        "wp-cli/wp-cli": "2.8.1"
+        "phpstan/phpstan": "^1.0 || ^2.0",
+        "szepeviktor/phpstan-wordpress": "^1.0 || ^2.0",
+        "wp-cli/wp-cli": "2.11"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/includes/class-integrate-convertkit-wpforms-creator-network-recommendations.php
+++ b/includes/class-integrate-convertkit-wpforms-creator-network-recommendations.php
@@ -477,7 +477,7 @@ class Integrate_ConvertKit_WPForms_Creator_Network_Recommendations {
 		// Sanity check that we're using the ConvertKit WordPress Libraries 1.3.7 or higher.
 		// If another ConvertKit Plugin is active and out of date, its libraries might
 		// be loaded that don't have this method.
-		if ( ! method_exists( $api, 'recommendations_script' ) ) {
+		if ( ! method_exists( $api, 'recommendations_script' ) ) { // @phpstan-ignore-line Older WordPress Libraries won't have this method.
 			delete_option( $this->creator_network_recommendations_script_key . '_' . $account_id );
 			return false;
 		}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -24,6 +24,9 @@ parameters:
     scanFiles:
         - /home/runner/work/convertkit-wpforms/convertkit-wpforms/wordpress/wp-config.php
 
+    # Don't report unmatched ignored errors on older PHP versions (7.2, 7.3)
+    reportUnmatchedIgnoredErrors: false
+
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
     level: 5

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -20,6 +20,13 @@ parameters:
     scanDirectories:
         - /home/runner/work/convertkit-wpforms/convertkit-wpforms/wordpress/wp-content/plugins
 
+    # Location of constants for PHPStan to scan, building symbols.
+    scanFiles:
+        - /home/runner/work/convertkit-wpforms/convertkit-wpforms/wordpress/wp-config.php
+
+    # Don't report unmatched ignored errors on older PHP versions (7.2, 7.3)
+    reportUnmatchedIgnoredErrors: false
+
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
     level: 5

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -24,9 +24,6 @@ parameters:
     scanFiles:
         - /home/runner/work/convertkit-wpforms/convertkit-wpforms/wordpress/wp-config.php
 
-    # Don't report unmatched ignored errors on older PHP versions (7.2, 7.3)
-    reportUnmatchedIgnoredErrors: false
-
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
     level: 5

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -24,6 +24,9 @@ parameters:
     scanFiles:
         - /home/runner/work/convertkit-wpforms/convertkit-wpforms/wordpress/wp-config.php
 
+    # Don't report unmatched ignored errors on older PHP versions (7.2, 7.3)
+    reportUnmatchedIgnoredErrors: false
+
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
     level: 5

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -20,6 +20,13 @@ parameters:
     scanDirectories:
         - /home/runner/work/convertkit-wpforms/convertkit-wpforms/wordpress/wp-content/plugins
 
+    # Location of constants for PHPStan to scan, building symbols.
+    scanFiles:
+        - /home/runner/work/convertkit-wpforms/convertkit-wpforms/wordpress/wp-config.php
+
+    # Don't report unmatched ignored errors on older PHP versions (7.2, 7.3)
+    reportUnmatchedIgnoredErrors: false
+
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
     level: 5

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -24,9 +24,6 @@ parameters:
     scanFiles:
         - /home/runner/work/convertkit-wpforms/convertkit-wpforms/wordpress/wp-config.php
 
-    # Don't report unmatched ignored errors on older PHP versions (7.2, 7.3)
-    reportUnmatchedIgnoredErrors: false
-
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
     level: 5


### PR DESCRIPTION
## Summary

Runs static analysis using the latest [2.0](https://github.com/phpstan/phpstan/blob/2.0.x/UPGRADING.md) version of PHPStan when tests are performed on PHP 7.4 and higher, which is the minimum supported version.

PHPStan 1.x will run on tests using PHP < 7.4.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)