### PR TITLE
Form Subscribe: Add `referrer` support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "2.0.5"
+        "convertkit/convertkit-wordpress-libraries": "dev-add-form-referrer-support"
     },
     "require-dev": {
         "lucatume/wp-browser": "<3.5",

--- a/includes/class-integrate-convertkit-wpforms.php
+++ b/includes/class-integrate-convertkit-wpforms.php
@@ -373,7 +373,11 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 							$response = $api->add_subscriber_to_legacy_form( $resource['id'], $subscriber['subscriber']['id'] );
 						} else {
 							// Add subscriber to form.
-							$response = $api->add_subscriber_to_form( $resource['id'], $subscriber['subscriber']['id'] );
+							$response = $api->add_subscriber_to_form(
+								$resource['id'],
+								$subscriber['subscriber']['id'],
+								$this->get_referrer_url( $form_data )
+							);
 						}
 						break;
 
@@ -461,6 +465,34 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 				)
 			);
 		}
+
+	}
+
+	/**
+	 * Gets the referrer URL to send to the `form_subscribe` API method.
+	 *
+	 * Falls back to the action's AJAX URL if the Post ID the form was
+	 * embedded in cannot be determined.
+	 *
+	 * @since   1.7.9
+	 *
+	 * @return  string
+	 */
+	private function get_referrer_url( $form_data ) {
+
+		// If the form data includes the referer, return that URL
+		// as it will include any UTM parameters.
+		if ( array_key_exists( 'entry_meta', $form_data ) && array_key_exists( 'referer', $form_data['entry_meta'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return esc_url( $form_data['entry_meta']['referer'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		}
+
+		// If the request includes the page_url, return that URL
+		if ( array_key_exists( 'page_url', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return esc_url( $_REQUEST['page_url'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		}
+
+		// Return the AJAX URL.
+		return home_url( add_query_arg( null, null ) );
 
 	}
 

--- a/includes/class-integrate-convertkit-wpforms.php
+++ b/includes/class-integrate-convertkit-wpforms.php
@@ -476,6 +476,7 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 	 *
 	 * @since   1.7.9
 	 *
+	 * @param   array $form_data Form data and settings.
 	 * @return  string
 	 */
 	private function get_referrer_url( $form_data ) {
@@ -486,7 +487,7 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 			return esc_url( $form_data['entry_meta']['referer'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
 
-		// If the request includes the page_url, return that URL
+		// If the request includes the page_url, return that URL.
 		if ( array_key_exists( 'page_url', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return esc_url( $_REQUEST['page_url'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -114,6 +114,46 @@ class ConvertKitAPI extends \Codeception\Module
 	}
 
 	/**
+	 * Check the given subscriber ID has been assigned to the given form ID.
+	 *
+	 * @since   1.7.9
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   int              $subscriberID  Subscriber ID.
+	 * @param   int              $formID        Form ID.
+	 * @param   string           $referrer      Referrer.
+	 */
+	public function apiCheckSubscriberHasForm($I, $subscriberID, $formID, $referrer = false)
+	{
+		// Run request.
+		$results = $this->apiRequest(
+			'forms/' . $formID . '/subscribers',
+			'GET',
+			[
+				// Check all subscriber states.
+				'status' => 'all',
+			]
+		);
+
+		// Iterate through subscribers.
+		$subscriberHasForm = false;
+		foreach ($results['subscribers'] as $subscriber) {
+			if ($subscriber['id'] === $subscriberID) {
+				$subscriberHasForm = true;
+				break;
+			}
+		}
+
+		// Assert if the subscriber has the form.
+		$this->assertTrue($subscriberHasForm);
+
+		// If a referrer is specified, assert it matches the subscriber's referrer now.
+		if ($referrer) {
+			$I->assertEquals($subscriber['referrer'], $referrer);
+		}
+	}
+
+	/**
 	 * Check the given subscriber ID has been assigned to the given sequence ID.
 	 *
 	 * @since   1.7.2

--- a/tests/acceptance/forms/FormCest.php
+++ b/tests/acceptance/forms/FormCest.php
@@ -58,7 +58,18 @@ class FormCest
 		);
 
 		// Check API to confirm subscriber was sent.
-		$I->apiCheckSubscriberExists($I, $emailAddress, 'First');
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress, 'First');
+
+		// Load page with Form so grabFromCurrentUrl() returns correct URL.
+		$I->amOnPage('/?p=' . $pageID);
+
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriberID,
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL'] . $I->grabFromCurrentUrl()
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Specifies the URL a WPForms Form is embedded in as the `referrer` parameter, when configured to subscribe the email address to a Kit Form.

![Screenshot 2025-01-02 at 14 02 45](https://github.com/user-attachments/assets/15434ef1-40f8-4731-bb37-ad47d8ea0bbf)


![Screenshot 2025-01-02 at 14 02 40](https://github.com/user-attachments/assets/faf47508-029f-41d0-bc5f-49deab0d9b73)

## Testing

- `testCreateFormToConvertKitFormMapping`: Updated test to confirm the subscriber is subscribed to the Kit Form, and has the expected referrer URL.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)