### PR TITLE
Tests: Fix upgrade test settings structure

### DIFF
--- a/tests/acceptance/general/UpgradePathsCest.php
+++ b/tests/acceptance/general/UpgradePathsCest.php
@@ -110,6 +110,7 @@ class UpgradePathsCest
 			'field_id'  => '0',
 			'settings'  => [
 				'store_spam_entries' => '0',
+				'submit_text'        => 'Submit',
 			],
 		];
 


### PR DESCRIPTION
## Summary

Fix upgrade test settings structure to mirror WPForms Lite 1.9.3.1+, as they are currently failing:
![Screenshot 2025-01-22 at 11 36 24](https://github.com/user-attachments/assets/1cd16fb5-670d-4f44-a017-d0899f8ac285)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)