### PR TITLE
Use `WordPress` Coding Standards ruleset

### DIFF
--- a/includes/class-integrate-convertkit-wpforms.php
+++ b/includes/class-integrate-convertkit-wpforms.php
@@ -489,7 +489,7 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 
 		// If the request includes the page_url, return that URL.
 		if ( array_key_exists( 'page_url', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			return esc_url( $_REQUEST['page_url'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return esc_url( sanitize_text_field( wp_unslash( $_REQUEST['page_url'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
 
 		// Return the AJAX URL.
@@ -715,7 +715,7 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 				sprintf(
 					'%s %s',
 					esc_html__( 'Kit: ', 'integrate-convertkit-wpforms' ),
-					sanitize_text_field( $_REQUEST['error_description'] ) // phpcs:ignore WordPress.Security.NonceVerification
+					sanitize_text_field( wp_unslash( $_REQUEST['error_description'] ) ) // phpcs:ignore WordPress.Security.NonceVerification
 				)
 			);
 		}
@@ -733,7 +733,7 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 		if ( ! array_key_exists( 'page', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return;
 		}
-		if ( $_REQUEST['page'] !== 'wpforms-settings' ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( sanitize_text_field( wp_unslash( $_REQUEST['page'] ) ) !== 'wpforms-settings' ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return;
 		}
 
@@ -750,7 +750,7 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 		}
 
 		// Sanitize token.
-		$authorization_code = sanitize_text_field( $_REQUEST['code'] ); // phpcs:ignore WordPress.Security.NonceVerification
+		$authorization_code = sanitize_text_field( wp_unslash( $_REQUEST['code'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 
 		// Exchange the authorization code and verifier for an access token.
 		$api    = new Integrate_ConvertKit_WPForms_API(
@@ -843,7 +843,7 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 		}
 
 		// Sanitize data.
-		$account_id = sanitize_text_field( $_POST['key'] );
+		$account_id = sanitize_text_field( wp_unslash( $_POST['key'] ) );
 
 		// Get API instance.
 		$api = $this->get_api_instance( $account_id );

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,8 +10,8 @@
 	<!-- Exclude minified Javascript files. -->
 	<exclude-pattern>*.min.js</exclude-pattern>
 
-	<!-- Check that code meets WordPress-Extra standards. -->
-	<rule ref="WordPress-Extra">
+	<!-- Check that code meets WordPress standards - this includes core, docs and extra. -->
+	<rule ref="WordPress">
 		<!--
 		We may want a middle ground though. The best way to do this is add the
 		entire ruleset, then rule by rule, remove ones that don't suit a project.
@@ -29,12 +29,10 @@
 		<exclude name="WordPress.Security.EscapeOutput"/>
 		-->
 		<exclude name="WordPress.PHP.YodaConditions" />
+		<exclude name="WordPress.DB.SlowDBQuery.slow_db_query_meta_query" />
 		<exclude name="PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose" />
 		<exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody" />
 	</rule>
-
-	<!-- Check that code is documented to WordPress Standards. -->
-	<rule ref="WordPress-Docs"/>
 
 	<!-- Add in some extra rules from other standards. -->
 	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>


### PR DESCRIPTION
## Summary

Currently, we implement `WordPress-Docs` and `WordPress-Extra` (which, in turn implements `WordPress-Core`) coding standards.

However, switching this to the complete [`WordPress` ruleset](https://github.com/WordPress/WordPress-Coding-Standards?tab=readme-ov-file#standards-subsets) (which lists itself as comprising of `WordPress-Core`, `WordPress-Docs` and `WordPress-Extra`) introduces some additional rulesets.

This PR updates code to meet these coding standards, primarily covering checking and unslashing superglobals in PHP.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)