### PR TITLE
Include `tenant_name` site URL on upgrade from v3 to v4 API

### DIFF
--- a/includes/class-integrate-convertkit-wpforms-setup.php
+++ b/includes/class-integrate-convertkit-wpforms-setup.php
@@ -164,7 +164,8 @@ class Integrate_ConvertKit_WPForms_Setup {
 			);
 			$result = $api->get_access_token_by_api_key_and_secret(
 				$settings['api_key'],
-				$settings['api_secret']
+				$settings['api_secret'],
+				get_site_url()
 			);
 
 			// Bail if an error occured.


### PR DESCRIPTION
## Summary

Includes the [`tenant_name` parameter](https://github.com/Kit/convertkit/pull/33052) as the WordPress site URL when calling `get_access_token_by_api_key_and_secret()` to fetch an access token using a v3 API Key and Secret, when users upgrade from < 1.7.0 to 1.7.0 or higher.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)