### PR TITLE
Tests: Add compatibility with chromedriver v134

### DIFF
--- a/includes/class-integrate-convertkit-wpforms-setup.php
+++ b/includes/class-integrate-convertkit-wpforms-setup.php
@@ -164,7 +164,8 @@ class Integrate_ConvertKit_WPForms_Setup {
 			);
 			$result = $api->get_access_token_by_api_key_and_secret(
 				$settings['api_key'],
-				$settings['api_secret']
+				$settings['api_secret'],
+				get_site_url()
 			);
 
 			// Bail if an error occured.

--- a/integrate-convertkit-wpforms.php
+++ b/integrate-convertkit-wpforms.php
@@ -54,8 +54,6 @@ if ( ! class_exists( 'ConvertKit_Review_Request' ) ) {
  */
 function integrate_convertkit_wpforms() {
 
-	load_plugin_textdomain( 'integrate-convertkit-wpforms', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
-
 	require_once plugin_dir_path( __FILE__ ) . '/includes/class-integrate-convertkit-wpforms-api.php';
 	require_once plugin_dir_path( __FILE__ ) . '/includes/class-integrate-convertkit-wpforms-creator-network-recommendations.php';
 	require_once plugin_dir_path( __FILE__ ) . '/includes/class-integrate-convertkit-wpforms-resource.php';

--- a/tests/Support/Helper/ThirdPartyPlugin.php
+++ b/tests/Support/Helper/ThirdPartyPlugin.php
@@ -15,34 +15,27 @@ class ThirdPartyPlugin extends \Codeception\Module
 	 *
 	 * @since   1.4.0
 	 *
-	 * @param   EndToEndTester $I     Tester.
-	 * @param   string         $name  Plugin Slug.
+	 * @param   EndToEndTester $I                       EndToEndTester.
+	 * @param   string         $name                    Plugin Slug.
 	 */
 	public function activateThirdPartyPlugin($I, $name)
 	{
-		// Login as the Administrator.
-		$I->loginAsAdmin();
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $this->amLoggedInAsAdmin($I) ) {
+			$this->doLoginAsAdmin($I);
+		}
 
 		// Go to the Plugins screen in the WordPress Administration interface.
 		$I->amOnPluginsPage();
 
+		// Wait for the Plugins page to load.
+		$I->waitForElementVisible('body.plugins-php');
+
 		// Activate the Plugin.
 		$I->activatePlugin($name);
 
-		// Go to the Plugins screen again; this prevents any Plugin that loads a wizard-style screen from
-		// causing seePluginActivated() to fail.
-		$I->amOnPluginsPage();
-
-		// Some Plugins have a different slug when activated.
-		switch ($name) {
-			case 'gravity-forms':
-				$I->seePluginActivated('gravityforms');
-				break;
-
-			default:
-				$I->seePluginActivated($name);
-				break;
-		}
+		// Wait for the Plugins page to load with the Plugin activated, to confirm it activated.
+		$I->waitForElementVisible('table.plugins tr[data-slug=' . $name . '].active');
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -54,24 +47,72 @@ class ThirdPartyPlugin extends \Codeception\Module
 	 *
 	 * @since   1.4.0
 	 *
-	 * @param   EndToEndTester $I      Tester.
+	 * @param   EndToEndTester $I      EndToEnd Tester.
 	 * @param   string         $name   Plugin Slug.
 	 */
 	public function deactivateThirdPartyPlugin($I, $name)
 	{
-		// Login as the Administrator.
-		$I->loginAsAdmin();
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $this->amLoggedInAsAdmin($I) ) {
+			$this->doLoginAsAdmin($I);
+		}
 
 		// Go to the Plugins screen in the WordPress Administration interface.
 		$I->amOnPluginsPage();
 
+		// Wait for the Plugins page to load.
+		$I->waitForElementVisible('body.plugins-php');
+
 		// Deactivate the Plugin.
 		$I->deactivatePlugin($name);
+	}
 
-		// Wait for notice to display.
-		$I->waitForElementVisible('div.updated');
+	/**
+	 * Helper method to check if the Administrator is logged in.
+	 *
+	 * @since   1.8.1
+	 * @param   EndToEndTester $I      EndToEnd Tester.
+	 *
+	 * @return  bool
+	 */
+	public function amLoggedInAsAdmin($I)
+	{
+		$cookies = $I->grabCookiesWithPattern('/^wordpress_logged_in_[a-z0-9]{32}$/');
+		return ! is_null( $cookies );
+	}
 
-		// Check that the Plugin deactivated successfully.
-		$I->seePluginDeactivated($name);
+	/**
+	 * Helper method to reliably login as the Administrator.
+	 *
+	 * @since   1.8.1
+	 *
+	 * @param   EndToEndTester $I      EndToEnd Tester.
+	 */
+	public function doLoginAsAdmin($I)
+	{
+		// Add admin_email_lifespan option to prevent Administration email verification screen from
+		// displaying on login, which causes tests to fail.
+		// This is included in the dump.sql file, but seems to be deleted after a test.
+		$I->haveOptionInDatabase('admin_email_lifespan', '1805512805');
+
+		// Load login screen.
+		$I->amOnPage('wp-login.php');
+
+		// Wait for the login form to load.
+		$I->waitForElementVisible('#user_login');
+		$I->waitForElementVisible('#user_pass');
+		$I->waitForElementVisible('#wp-submit');
+
+		// Fill in the login form.
+		$I->click('#user_login');
+		$I->fillField('#user_login', $_ENV['WORDPRESS_ADMIN_USER']);
+		$I->click('#user_pass');
+		$I->fillField('#user_pass', $_ENV['WORDPRESS_ADMIN_PASSWORD']);
+
+		// Submit.
+		$I->click('#wp-submit');
+
+		// Wait for the Dashboard page to load, to confirm login succeeded.
+		$I->waitForElementVisible('body.index-php');
 	}
 }

--- a/tests/Support/Helper/WPForms.php
+++ b/tests/Support/Helper/WPForms.php
@@ -570,8 +570,10 @@ class WPForms extends \Codeception\Module
 	 */
 	public function disconnectAccount($I, $accountID)
 	{
-		// Login as admin.
-		$I->loginAsAdmin();
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $I->amLoggedInAsAdmin($I) ) {
+			$I->doLoginAsAdmin($I);
+		}
 
 		// Click Disconnect.
 		$I->amOnAdminPage('admin.php?page=wpforms-settings&view=integrations');


### PR DESCRIPTION
## Summary

[It seems that this chromedriver v134 bug](https://issues.chromium.org/issues/402796660) results in tests failing due to methods such as `click_button` return control to the test before fully completing.  There's also a lot of other repositories having similar issues with a [variety of test frameworks](https://github.com/teamcapybara/capybara/issues/2800).

Fixes tests by ensuring elements are fully loaded before attempting to perform the next step.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)