### PR TITLE
Add `devcontainer` configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,73 @@
+{
+    "name": "WordPress Codespace",
+    "image": "ghcr.io/automattic/vip-codespaces/alpine-base:latest",
+    "overrideCommand": false,
+    "forwardPorts": [80, 81, 8025],
+    "portsAttributes": {
+        "80": {
+            "label": "Application",
+            "onAutoForward": "notify",
+            "elevateIfNeeded": true
+        },
+        "81": {
+            "label": "phpMyAdmin",
+            "onAutoForward": "notify",
+            "elevateIfNeeded": true
+        },
+        "3306": {
+            "label": "MySQL",
+            "onAutoForward": "ignore"
+        },
+        "9000": {
+            "label": "php-fpm",
+            "onAutoForward": "ignore"
+        },
+        "9003": {
+            "label": "Xdebug Client Port",
+            "onAutoForward": "notify"
+        }
+    },
+    "features": {
+        "ghcr.io/automattic/vip-codespaces/base:latest": {},
+        "ghcr.io/automattic/vip-codespaces/nginx:latest": {},
+        "ghcr.io/automattic/vip-codespaces/php:latest": {
+            "version": "8.2",
+            "composer": true
+        },
+        "ghcr.io/automattic/vip-codespaces/mariadb:latest": {
+            // Set to false to prevent the database content from persisting between rebuilds.
+            "installDatabaseToWorkspaces": true
+        },
+        "ghcr.io/automattic/vip-codespaces/wordpress:latest": {
+            // WordPress version: Accepts 'latest', 'nightly', or a version number.
+            "version": "latest",
+            // Set to false to prevent wp-content/uploads content from persisting between rebuilds.
+            "moveUploadsToWorkspaces": false,
+            // Set to true to create the environment as a WordPress multisite.
+            "multisite": false,
+            // GitHub Codespaces only supports the subdirectory network type for multisite; subdomain cannot be used.
+            "multisiteStyle": "subdirectory"
+        },
+        "ghcr.io/automattic/vip-codespaces/wp-cli:latest": {
+            // Set to true to enable nightly builds of WP-CLI.
+            "nightly": false
+        },
+        "ghcr.io/automattic/vip-codespaces/dev-tools:latest": {},
+        "ghcr.io/automattic/vip-codespaces/phpmyadmin:latest": {
+            // Set to false to disable phpMyAdmin.
+            "enabled": true
+        },
+        "ghcr.io/automattic/vip-codespaces/xdebug:latest": {
+            // Set to true to enable Xdebug.
+            // This setting can also be updated with CLI commands in the terminal.
+            "enabled": true,
+            // Set Xdebug mode. Accepted value options are listed here: https://xdebug.org/docs/all_settings#mode
+            "mode": "debug"
+        },
+        "ghcr.io/automattic/vip-codespaces/ssh:latest": {
+            // Set to true to enable an SSH server for the Codespaces environment.
+            "enabled": true
+        }
+    },
+    "postCreateCommand": "bash ./.devcontainer/post-create.sh"
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Install Free Third Party WordPress Plugins 
+wp plugin install classic-editor wpforms-lite
+
+# Install Default WordPress Theme
+wp theme install twentytwentyfive
+
+# Symlink Plugin
+ln -s /workspaces/convertkit-wpforms /wp/wp-content/plugins/integrate-convertkit-wpforms
+
+# Run Composer in Plugin Directory to build
+cd /wp/wp-content/plugins/integrate-convertkit-wpforms
+composer update
+
+# Activate Plugins
+wp plugin activate wpforms-lite integrate-convertkit-wpforms

--- a/phpstan-dev.neon
+++ b/phpstan-dev.neon
@@ -1,0 +1,29 @@
+# PHPStan configuration for Dev Containers
+
+# Include PHPStan for WordPress configuration.
+includes:
+    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+
+# Parameters
+parameters:
+    # Paths to scan
+    # This should comprise of the base Plugin PHP file, plus directories that contain Plugin PHP files
+    paths:
+        - integrate-convertkit-wpforms.php
+        - includes/
+
+    # Files that include Plugin-specific PHP constants
+    bootstrapFiles:
+        - integrate-convertkit-wpforms.php
+
+    # Location of WordPress Plugins for PHPStan to scan, building symbols.
+    scanDirectories:
+        - /wp/wp-content/plugins
+
+    # Location of constants, Kit helper functions and Kit WordPress Libraries for PHPStan to scan, building symbols.
+    scanFiles:
+        - /wp/wp-config.php
+
+    # Should not need to edit anything below here
+    # Rule Level: https://phpstan.org/user-guide/rule-levels
+    level: 5


### PR DESCRIPTION
## Summary

Adds a `devcontainer.json` configuration to facilitate running a dev container locally or in GitHub Codespaces, using [WPVIP's configuration](https://docs.wpvip.com/local-development/github-codespaces/), which provides a ready made nginx, PHP, MySQL and WordPress setup.

Codespace example:
http://bug-free-yodel-pj4gxwwj9w29p6x-80.app.github.dev/
http://bug-free-yodel-pj4gxwwj9w29p6x-80.app.github.dev/wp-admin

- User: vipgo
- Pass: password

![Screenshot 2025-04-21 at 15 15 59](https://github.com/user-attachments/assets/552a5e21-f309-438b-9603-2e90c21476ac)

![Screenshot 2025-04-21 at 15 14 52](https://github.com/user-attachments/assets/e489b6a4-00c5-42f9-87ca-1bd508be4b50)

![Screenshot 2025-04-21 at 15 15 36](https://github.com/user-attachments/assets/5421f87d-b9fd-4cfe-8176-12c49bb2a811)

Codeception (for end to end testing) isn't yet configured, as this requires chromedriver to run in a separate process.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)