### PR TITLE
Add WordPress Playground GitHub Action

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -1,0 +1,88 @@
+name: WordPress Playground PR Testing
+
+# When to run tests.
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  build-and-deploy:
+    # Name.
+    name: WordPress Playground
+
+    # Virtual Environment to use.
+    # @see: https://github.com/actions/virtual-environments
+    runs-on: ubuntu-latest
+
+    # Define permissions for this action.
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+
+    # Environment Variables.
+    # Accessible by using ${{ env.NAME }}
+    # Use ${{ secrets.NAME }} to include any GitHub Secrets in ${{ env.NAME }}
+    # The base folder will always be /home/runner/work/github-repo-name/github-repo-name
+    env:
+      PLUGIN_SLUG: "integrate-convertkit-wpforms" # The plugin's slug
+      AWS_ROLE: "arn:aws:iam::048876701201:role/KitWPPluginBuildsRole"
+      AWS_ROLE_SESSION_NAME: "kit-wordpress"
+      AWS_BUCKET: "048876701201-kit-wp-plugin-builds" # The Amazon S3 bucket name
+      AWS_REGION: "us-east-2" # The Amazon S3 region
+
+    # Steps to build and provide the Playground URL
+    steps:
+      # Checkout (copy) this repository's Plugin to this VM.
+      - name: Checkout Plugin
+        uses: actions/checkout@v4
+
+      # Installs Kit WordPress Libraries.
+      - name: Run Composer
+        run: composer install --no-dev
+
+      # Configure AWS Credentials
+      - name: Configure AWS credentials
+        id: credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE }}
+          role-session-name: ${{ env.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # Create ZIP file
+      - name: Create ZIP File
+        run: |
+          zip -r ${{ env.PLUGIN_SLUG }}.zip . -x ".git/*" ".github/*" ".scripts/*" ".wordpress-org/*" "log/*" "tests/*" "*.md" "*.yml" "*.json" "*.neon" "*.lock" "*.xml" "*.dist" "*.example"
+
+      # Create base64 encoded version of blueprint JSON for Playground URL.
+      # See: https://wordpress.github.io/wordpress-playground/blueprints/using-blueprints#base64-encoded-blueprints
+      - name: Create Blueprint JSON, Base64 Encoded
+        id: blueprint
+        run: |
+          echo "blueprint_json_base64=$(echo -n '{"landingPage": "/wp-admin/index.php","login":true,"steps":[{"step":"installPlugin","pluginData":{"resource":"wordpress.org/plugins","slug":"wpforms-lite"}},{"step":"installPlugin","pluginData":{"resource":"url","url":"https://${{ env.AWS_BUCKET }}.s3.${{ env.AWS_REGION }}.amazonaws.com/${{ env.PLUGIN_SLUG }}/${{ github.event.pull_request.number }}/${{ env.PLUGIN_SLUG }}.zip"}}]}' | base64 -w 0)" >> $GITHUB_OUTPUT
+
+      # Upload to S3
+      - name: Upload to S3
+        id: upload-s3
+        run: |
+          aws s3 cp ${{ env.PLUGIN_SLUG }}.zip s3://${{ env.AWS_BUCKET }}/${{ env.PLUGIN_SLUG }}/${{ github.event.pull_request.number }}/${{ env.PLUGIN_SLUG }}.zip
+
+      # Add comment to PR linking to Playground
+      - name: Comment on PR
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## WordPress Playground
+              
+              :rocket: Your PR has been built and is ready for testing in WordPress Playground!
+              
+              [Click here to test your changes in WordPress Playground](https://playground.wordpress.net/#${{ steps.blueprint.outputs.blueprint_json_base64 }})`
+            })


### PR DESCRIPTION
## Summary

Adds a GitHub Action to create automatic preview links to view the Plugin build for an open PR on [WordPress Playground](https://playground.wordpress.net/), adding a link to the preview build in the PR's comment.

![Screenshot 2025-03-03 at 16 22 56](https://github.com/user-attachments/assets/4ac40ed1-0d08-4b80-8f77-e7a5abd6d5a9)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)