### PR TITLE
Tests: Revert Codeception 5.2 or 5.3 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,7 @@
         "wp-coding-standards/wpcs": "^3.0.0",
         "phpstan/phpstan": "^1.0 || ^2.0",
         "szepeviktor/phpstan-wordpress": "^1.0 || ^2.0",
-        "lucatume/wp-browser": "^3.0 || ^4.0",
-        "codeception/codeception": "^2.5 || ^3.0 || ^4.0 || ^5.2 || ^5.3",
-        "behat/gherkin": "4.10.0 || 4.12.0"
+        "lucatume/wp-browser": "^3.0 || ^4.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
## Summary

Reverts [this PR](https://github.com/Kit/convertkit-wpforms/pull/91), as Codeception 5.2.2 is now available, backporting support for PHP 8.1: https://github.com/Codeception/Codeception/releases.

`codeception/codeception` and `behat/gherkin` version constraints are no longer needed in `composer.json`.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)