### PR TITLE
Add New Connection via Form Builder

### DIFF
--- a/includes/class-integrate-convertkit-wpforms-resource.php
+++ b/includes/class-integrate-convertkit-wpforms-resource.php
@@ -2,7 +2,7 @@
 /**
  * ConvertKit Resource class.
  *
- * @package CKWC
+ * @package ConvertKit_WPForms
  * @author ConvertKit
  */
 

--- a/resources/backend/js/form-builder.js
+++ b/resources/backend/js/form-builder.js
@@ -12,7 +12,7 @@
  *
  * @since 1.8.4
  */
-const IntegrateConvertKitWPFormsOauth = function () {
+const IntegrateConvertKitWPFormsOauth = (function () {
 
 	/**
 	 * Public functions and properties.
@@ -117,7 +117,7 @@ const IntegrateConvertKitWPFormsOauth = function () {
 
 	// Provide access to public functions/properties.
 	return app;
-};
+})();
 
 // Initialize.
 IntegrateConvertKitWPFormsOauth.init();

--- a/resources/backend/js/form-builder.js
+++ b/resources/backend/js/form-builder.js
@@ -1,0 +1,123 @@
+/**
+ * Kit Oauth Popup.
+ *
+ * @since 1.8.4
+ *
+ * @package Integrate_ConvertKit_WPForms
+ * @author ConvertKit
+ */
+
+/**
+ * Show and hide the Kit OAuth popup window.
+ *
+ * @since 1.8.4
+ */
+const IntegrateConvertKitWPFormsOauth = function () {
+
+	/**
+	 * Public functions and properties.
+	 *
+	 * @since 1.8.4
+	 *
+	 * @type {Object}
+	 */
+	const app = {
+
+		/**
+		 * If the OAuth popup is open.
+		 *
+		 * @since 1.8.4
+		 */
+		isOpened : false,
+
+		/**
+		 * Initialize.
+		 *
+		 * @since 1.8.4
+		 */
+		init: function () {
+
+			// Show the OAuth popup window when the user clicks the "Connect to Kit" button
+			// when editing a WPForms Form at Marketing > Kit.
+			document.addEventListener(
+				'click',
+				function ( e ) {
+					if ( e.target.matches( 'a[data-provider="convertkit"]' ) ) {
+						app.showWindow( e );
+					}
+				}
+			);
+
+		},
+
+		/**
+		 * Show the OAuth popup window.
+		 *
+		 * @since 1.8.4
+		 *
+		 * @param {Event} e Click event.
+		 */
+		showWindow: function ( e ) {
+
+			e.preventDefault();
+
+			if ( app.isOpened ) {
+				return;
+			}
+
+			// Define popup width, height and positioning.
+			const 	width  = 640,
+					height = 750,
+					top    = ( window.screen.height - height ) / 2,
+					left   = ( window.screen.width - width ) / 2;
+
+			// Open popup.
+			const kitPopup = window.open(
+				e.target.href,
+				'convertkit_popup_window',
+				'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=' + width + ',height=' + height + ',top=' + top + ',left=' + left
+			);
+
+			// Center popup and focus.
+			kitPopup.moveTo( left, top );
+			kitPopup.focus();
+
+			// Mark popup as opened.
+			app.isOpened = true;
+
+			// Refresh the form builder when the popup is closed using self.close().
+			// Won't fire if the user closes the popup manually, which is fine because that means
+			// they didn't complete the steps, so refreshing wouldn't show anything new.
+			// The onbeforeunload would seem suitable here, but it fires whenever the popup window's
+			// document changes (e.g. as the user steps through OAuth flow), and doesn't fire when
+			// the window is closed.
+			// See https://stackoverflow.com/questions/9388380/capture-the-close-event-of-popup-window-in-javascript/48240128#48240128.
+			const checkWindowClosed = setInterval(
+				function () {
+					if ( kitPopup.closed ) {
+						clearInterval( checkWindowClosed );
+
+						// Save the form builder and reload, to reflect the changes.
+						WPFormsBuilder.formSave( false ).done(
+							function () {
+								WPFormsBuilder.setCloseConfirmation( false );
+								WPFormsBuilder.showLoadingOverlay();
+								window.location.reload();
+							}
+						);
+
+						app.isOpened = false;
+					}
+				},
+				1000
+			);
+
+		}
+	};
+
+	// Provide access to public functions/properties.
+	return app;
+};
+
+// Initialize.
+IntegrateConvertKitWPFormsOauth.init();

--- a/tests/EndToEnd/forms/FormCest.php
+++ b/tests/EndToEnd/forms/FormCest.php
@@ -78,6 +78,78 @@ class FormCest
 	}
 
 	/**
+	 * Test that the connection can be added in the WPForms Form Builder,
+	 * if no connection exists at WPForms > Settings > Integrations.
+	 *
+	 * @since   1.8.4
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testAddNewConnectionInFormBuilder(EndToEndTester $I)
+	{
+		// Create Form.
+		$wpFormsID = $I->createWPFormsForm($I);
+
+		// Click Marketing icon.
+		$I->waitForElementVisible('.wpforms-panel-providers-button');
+		$I->click('.wpforms-panel-providers-button');
+
+		// Click Kit tab.
+		$I->click('#wpforms-panel-providers a.wpforms-panel-sidebar-section-convertkit');
+
+		// Click Add New Connection.
+		$I->click('Add New Connection');
+
+		// Define name for connection.
+		$I->waitForElementVisible('.jconfirm-content');
+		$I->fillField('#provider-connection-name', 'Kit');
+		$I->click('OK');
+
+		// Wait for Connect to Kit button to display, as no connections exist at WPForms > Settings > Integrations.
+		$I->waitForElementVisible('a[data-provider="convertkit"]');
+
+		// Click the button and confirm the OAuth popup displays.
+		$I->click('a[data-provider="convertkit"]');
+
+		// Switch to next browser tab, as the link opens in a new tab.
+		$I->switchToNextTab();
+
+		// Confirm the Kit login screen loaded.
+		$I->waitForElementVisible('input[name="user[email]"]');
+
+		// Add the provider tokens programmatically, as if the user completed OAuth.
+		$accountID = $I->setupWPFormsIntegration($I);
+
+		// Close tab, which will trigger the form builder to save and reload, showing the new connection.
+		$I->closeTab();
+		$I->wait(3);
+
+		// Wait for save to complete.
+		$I->waitForElementVisible('#wpforms-save:not(:disabled)');
+
+		// Click Add New Connection.
+		$I->click('Add New Connection');
+
+		// Define name for connection.
+		$I->waitForElementVisible('.jconfirm-content');
+		$I->fillField('#provider-connection-name', 'Kit');
+		$I->click('OK');
+
+		// Get the connection ID to confirm the connection was added.
+		$I->waitForElementVisible('.wpforms-provider-connections .wpforms-provider-connection');
+		$connectionID = $I->grabAttributeFrom('.wpforms-provider-connections .wpforms-provider-connection', 'data-connection_id');
+
+		// Confirm the connection was added.
+		$I->waitForElementVisible('div[data-connection_id="' . $connectionID . '"] .wpforms-provider-fields', 30);
+
+		// Click Save.
+		$I->click('#wpforms-save');
+
+		// Wait for save to complete.
+		$I->waitForElementVisible('#wpforms-save:not(:disabled)');
+	}
+
+	/**
 	 * Tests that the connection configured when editing a WPForms Form at Marketing > Kit is retained when:
 	 * - Connects to Kit at Settings > Integrations,
 	 * - Configures the connection at WPForms Form > Marketing > Kit,

--- a/views/backend/close-modal.php
+++ b/views/backend/close-modal.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Runs JS to close the OAuth popup window.
+ *
+ * @package ConvertKit_WPForms
+ * @author ConvertKit
+ */
+
+?>
+<!DOCTYPE html>
+<html>
+	<head>
+	</head>
+	<body>
+	</body>
+	<script type="text/javascript">
+		self.close();
+	</script>
+</html>


### PR DESCRIPTION
## Summary

If no connections are specified at `WPForms > Settings > Integrations`, the creator adds a new WPForms Form and then attempts to add a new connection within the WPForms form builder, no option would display to connect to Kit:

![Screenshot 2025-05-14 at 15 07 44](https://github.com/user-attachments/assets/8eee498a-49e4-41b6-bab5-c1bfe841339a)

This PR resolves by:
- Displaying the Connect to Kit button
- Allowing the user to connect their Kit account using OAuth
- Automatically saving and reloading the WPForms form builder, presenting the new connection, which can then be configured to send the form submission to Kit

![Screenshot 2025-05-14 at 14 24 33](https://github.com/user-attachments/assets/c7935db3-b7a1-4af7-990f-eb099354a79e)
![Screenshot 2025-05-14 at 14 24 42](https://github.com/user-attachments/assets/b3d41002-6b77-4f62-bcc9-cd1f53f72101)
![Screenshot 2025-05-14 at 14 25 13](https://github.com/user-attachments/assets/fdcf6bd4-7025-4521-bce8-3a6f6cc3e2fe)

## Testing

- `testAddNewConnectionInFormBuilder`: Test that a new connection can be added in the WPForms form builder

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)